### PR TITLE
Zip code and Organziation (CareSite) Fixes

### DIFF
--- a/src/main/java/edu/gatech/chai/omopv6/dba/service/CareSiteServiceImp.java
+++ b/src/main/java/edu/gatech/chai/omopv6/dba/service/CareSiteServiceImp.java
@@ -48,7 +48,7 @@ public class CareSiteServiceImp extends BaseEntityServiceImp<CareSite, CareSiteD
 	@Transactional(readOnly = true)
 	public CareSite searchByLocation(Location location) {
 		EntityManager em = getEntityDao().getEntityManager();
-		String query = "SELECT t FROM CareSite t WHERE location_id like :value";
+		String query = "SELECT t FROM CareSite t WHERE location_id = :value";
 		List<? extends CareSite> results = em.createQuery(query, CareSite.class)
 				.setParameter("value",location.getId()).getResultList();
 		if (results.size() > 0) {

--- a/src/main/java/edu/gatech/chai/omopv6/dba/service/LocationServiceImp.java
+++ b/src/main/java/edu/gatech/chai/omopv6/dba/service/LocationServiceImp.java
@@ -50,7 +50,7 @@ public class LocationServiceImp extends BaseEntityServiceImp<Location, LocationD
 		List<Location> results;
 		
 		if (line2 != null) {
-			query = "SELECT t FROM Location t WHERE address1 LIKE :line1 AND address2 LIKE :line2 AND city LIKE :city AND state LIKE :state AND zipCode LIKE :zip";
+			query = "SELECT t FROM Location t WHERE address1 LIKE :line1 AND address2 LIKE :line2 AND city LIKE :city AND state LIKE :state AND zip LIKE :zip";
 			results = em.createQuery(query, Location.class)
 					.setParameter("line1", line1)
 					.setParameter("line2", line2)
@@ -59,7 +59,7 @@ public class LocationServiceImp extends BaseEntityServiceImp<Location, LocationD
 					.setParameter("zip", zipCode)
 					.getResultList();
 		} else { 
-			query = "SELECT t FROM Location t WHERE address1 LIKE :line1 AND city LIKE :city AND state LIKE :state AND zipCode LIKE :zip";
+			query = "SELECT t FROM Location t WHERE address1 LIKE :line1 AND city LIKE :city AND state LIKE :state AND zip LIKE :zip";
 			results = em.createQuery(query, Location.class)
 					.setParameter("line1", line1)
 					.setParameter("city", city)


### PR DESCRIPTION
CareSiteServiceImp.java using LIKE with bigint and int requires type casting, but equals should be fine here.

LocationServiceImp.java zipCode should be changed to zip since in the HQL it is referring to the zipCode as being a column, but it is actually zip.